### PR TITLE
HAML 3.1.1以降にbundleされてくるSASS 3.1.0の持つBackwards Incompatibilities により，css生成失敗することへの対処

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem 'ci_reporter'
 end
 gem 'haml-rails'
+gem 'sass'
 gem 'jquery-rails'
 gem 'rcov'
 gem 'em-websocket'

--- a/public/stylesheets/sass/main.sass
+++ b/public/stylesheets/sass/main.sass
@@ -1,6 +1,6 @@
 // variable
-!link-color = #e2041b
-!link-visited-color = #e597b2
+$link-color: #e2041b
+$link-visited-color: #e597b2
 
 // layout
 body
@@ -209,21 +209,21 @@ img.profile
 
 // link
 a
-  :color !link-color
+  :color $link-color
   :font-style normal
   :text-decoration underline
 
 a:link
-  :color !link-color
+  :color $link-color
   :font-style normal
   :text-decoration underline
 
 a:visited
-  :color !link-visited-color
+  :color $link-visited-color
   :text-decoration underline
 
 a:hover
-  :color !link-color
+  :color $link-color
   :font-style normal
   :text-decoration underline
 


### PR DESCRIPTION
cf. http://sass-lang.com/docs/yardoc/file.SASS_CHANGELOG.html#backwards_incompatibilities__must_read

main.css生成時に以下のようにsyntax errorになって表示が崩れてしまうので，本pull requestは新しいsyntaxに合わせた修正です．

```
Syntax error: Invalid CSS after "": expected expression (e.g. 1px, bold), was "!link-color"   
        on line 212 of /home/noriyuki/work/AsakusaSatellite/public/stylesheets/sass/main.sass 

207:   .submit                                                                                
208:     :margin-top 20px                                                                     
209:                                                                                          
210: // link                                                                                  
211: a                                                                                        
212:   :color !link-color                                                                     
213:   :font-style normal                                                                     
214:   :text-decoration underline                                                             
215:                                                                                          
216: a:link                                                                                   
217:   :color !link-color                                                                     
```

ついでに，HAML 3.2からSASSをbundleしなくなるという起動時の下記警告メッセージに従った事前対応の修正も含みます．

```
=> Booting WEBrick                                                         
=> Rails 3.0.3 application starting in development on http://0.0.0.0:3000  
=> Call with -d to detach                                                  
=> Ctrl-C to shutdown server                                               
Sass is in the process of being separated from Haml,                       
and will no longer be bundled at all in Haml 3.2.0.                        
Please install the 'sass' gem if you want to use Sass.                     

Haml will no longer automatically load Sass in Haml 3.2.0.                 
Please add gem 'sass' to your Gemfile.                                     
```

ご確認下さい．よろしくおねがいします．
