### PR TITLE
Bad request: Invalid channel name

### DIFF
--- a/app/helpers/chat_helper.rb
+++ b/app/helpers/chat_helper.rb
@@ -64,7 +64,7 @@ module ChatHelper
            else
              { :content => to_json(message, room) }
            end
-    AsakusaSatellite::MessagePusher.trigger("as:#{room.id}",
+    AsakusaSatellite::MessagePusher.trigger("as-#{room.id}",
                                             "message_#{event}",
                                             data.to_json)
 

--- a/public/javascripts/jquery.websocket.js
+++ b/public/javascripts/jquery.websocket.js
@@ -34,7 +34,7 @@
                          fire('websocket::disconnect', e);
                      });
 
-        var channel = pusher.subscribe('as:' + config.room );
+        var channel = pusher.subscribe('as-' + config.room );
         channel.bind('message_create',
                      function(obj){
                          var obj = parse(obj);


### PR DESCRIPTION
はじめまして．

Herokuに対応されたということで触ってみています．Herokuでpusherの設定をしてメッセージを入力するとリロードされないのでログを見たところ，
Bad request: Invalid channel name 
というログが出力されていました．

http://pusher.com/docs/client_api_guide/client_channels
を見たところ，

```
Channel names should only include lower and uppercase letters, numbers and the following punctuation _ - = @ , . ;
```

とありました．":"が使えないようなので，"as-"としたところ，問題なく動作したのでpushしておきますが，より良い修正がありましたら，無視してください．

以上よろしくお願い致します．
