### PR TITLE
RedmineUser's name should be mail address

### DIFF
--- a/vendor/plugins/as_redmineauth_plugin/app/models/redmine_user.rb
+++ b/vendor/plugins/as_redmineauth_plugin/app/models/redmine_user.rb
@@ -15,7 +15,7 @@ class RedmineUser
   end
   
   def name
-    @document.root.elements['login'].text
+    @document.root.elements['mail'].text
   end
   
   def screen_name

--- a/vendor/plugins/as_redmineauth_plugin/spec/controllers/redmineauth_controller.rb
+++ b/vendor/plugins/as_redmineauth_plugin/spec/controllers/redmineauth_controller.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require File.dirname(__FILE__) + '/../../../../../spec/spec_helper'
 
 describe RedmineauthController do
@@ -14,7 +15,6 @@ describe RedmineauthController do
   it "validなユーザはログインできる" do
     response = """<user>
 <id>3</id>
-<login>loginname</login>
 <firstname>Firstname</firstname>
 <lastname>LastName</lastname>
 <mail>loginname@example.com</mail>


### PR DESCRIPTION
RedmineのAPIでは login エレメントが取れるのはログイン中のユーザがadmin権限をもっているときだけらしく

http://www.redmine.org/projects/redmine/repository/entry/trunk/app/views/users/show.api.rsb#L3

一般のアカウントでログインを試みた時に以下のようなエラーが出力されていました。

<pre>

Started POST "/redmineauth/login" for 192.168.1.217 at Thu Sep 06 11:55:08 +0900 2012
  Processing by RedmineauthController#login as HTML
  Parameters: {"commit"=>"Login", "utf8"=>"?", "login"=>{"key"=>"..."}, "authenticity_token"=>"..."}
MONGODB asakusa_satellite_development['system.namespaces'].find({})
MONGODB asakusa_satellite_development['users'].find({:_id=>nil}).limit(-1).sort(_idasc)
MONGODB asakusa_satellite_development['users'].find({:screen_name=>".."}).limit(-1).sort(_idasc)
Completed 500 Internal Server Error in 250ms

NoMethodError (undefined method `text' for nil:NilClass):
  

Rendered vendor/bundle/ruby/1.8/gems/actionpack-3.1.1/lib/action_dispatch/middleware/templates/rescues/_trace.erb (1.6ms)
Rendered vendor/bundle/ruby/1.8/gems/actionpack-3.1.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.erb (1.1ms)
Rendered vendor/bundle/ruby/1.8/gems/actionpack-3.1.1/lib/action_dispatch/middleware/templates/rescues/diagnostics.erb within rescues/layout (4.8ms)
</pre>


一般アカウントでも取得できる（公開情報である）メールアドレスをnameとして返すようにしたらどうでしょうか？
