### PR TITLE
Add: updating the name and the profile image of a user at login

### DIFF
--- a/vendor/plugins/as_redmineauth_plugin/app/controllers/redmineauth_controller.rb
+++ b/vendor/plugins/as_redmineauth_plugin/app/controllers/redmineauth_controller.rb
@@ -16,7 +16,9 @@ class RedmineauthController < ApplicationController
       user ||= User.new
       user.screen_name ||= redmine_user.name
       user.name ||= redmine_user.screen_name
-      user.profile_image_url = 'data:image/gif;base64,R0lGODlhEAAQAMQfAFWApnCexR4xU1SApaJ3SlB5oSg9ZrOVcy1HcURok/Lo3iM2XO/i1lJ8o2eVu011ncmbdSc8Zc6lg4212DZTgC5Hcmh3f8OUaDhWg7F2RYlhMunXxqrQ8n6s1f///////yH5BAEAAB8ALAAAAAAQABAAAAVz4CeOXumNKOpprHampAZltAt/q0Tvdrpmm+Am01MRGJpgkvBSXRSHYPTSJFkuws0FU8UBOJiLeAtuer6dDmaN6Uw4iNeZk653HIFORD7gFOhpARwGHQJ8foAdgoSGJA1/HJGRC40qHg8JGBQVe10kJiUpIQA7'
+      user.profile_image_url ||= 'data:image/gif;base64,R0lGODlhEAAQAMQfAFWApnCexR4xU1SApaJ3SlB5oSg9ZrOVcy1HcURok/Lo3iM2XO/i1lJ8o2eVu011ncmbdSc8Zc6lg4212DZTgC5Hcmh3f8OUaDhWg7F2RYlhMunXxqrQ8n6s1f///////yH5BAEAAB8ALAAAAAAQABAAAAVz4CeOXumNKOpprHampAZltAt/q0Tvdrpmm+Am01MRGJpgkvBSXRSHYPTSJFkuws0FU8UBOJiLeAtuer6dDmaN6Uw4iNeZk653HIFORD7gFOhpARwGHQJ8foAdgoSGJA1/HJGRC40qHg8JGBQVe10kJiUpIQA7'
+      user.name = params[:login][:name] if not params[:login][:name].blank?
+      user.profile_image_url = params[:login][:image_url] if not params[:login][:image_url].blank?
       user.save
       session[:current_user_id] = user.id
       redirect_to :controller => 'chat', :action => 'index'

--- a/vendor/plugins/as_redmineauth_plugin/app/views/redmineauth/login.html.haml
+++ b/vendor/plugins/as_redmineauth_plugin/app/views/redmineauth/login.html.haml
@@ -17,6 +17,19 @@
     .login-right
      =text_field :login, :key, {:class => :text, :placeholder => t(:input_your_key)}
     .clear
+   %legend{:align => :center, :style => "width:100%"}= t(:update_your_profile)
+   %div
+    .login-left
+     =label :login, :name, t(:name) + ":"
+    .login-right
+     =text_field :login, :name, {:class => :text}
+    .clear
+   %div
+    .login-left
+     =label :login, :image_url, t(:image_url) + ":"
+    .login-right
+     =text_field :login, :image_url, {:class => :text}
+    .clear
    %div{:style => "text-align:center;margin:10px;"}
     =submit_tag t(:login), :class => "submit red button large"
 

--- a/vendor/plugins/as_redmineauth_plugin/config/locales/en.yml
+++ b/vendor/plugins/as_redmineauth_plugin/config/locales/en.yml
@@ -1,3 +1,6 @@
 en:
  key: Redmine API access key
  input_your_key: Input your key
+ update_your_profile: Update your profile
+ name: Name
+ image_url: Profile image URL

--- a/vendor/plugins/as_redmineauth_plugin/spec/controllers/redmineauth_controller.rb
+++ b/vendor/plugins/as_redmineauth_plugin/spec/controllers/redmineauth_controller.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require File.dirname(__FILE__) + '/../../../../../spec/spec_helper'
 
 describe RedmineauthController do
@@ -32,4 +33,14 @@ describe RedmineauthController do
     session[:current_user_id].should be_nil
   end
 
+  it "ログイン時に名前とプロフィール画像URLを上書きできる" do
+    RestClient.stub(:get).and_return(VALID_API_RESPONSE)
+    post :login, :login => {
+      :key => 'dummy', :name => 'updated',
+      :image_url => 'http://www.example.com/updated.png'
+    }
+    u = User.find(session[:current_user_id])
+    u.name.should == "updated"
+    u.profile_image_url.should == "http://www.example.com/updated.png"
+  end
 end


### PR DESCRIPTION
RedmineAPIによる認証だと名前やプロフィール画像が変更できずに大変つらい思いをします。

ログイン時に名前やプロフィール画像を指定できるような仕様を思いつきました。
ログインの際に名前やプロフィール画像を指定しない場合は前の状態を保存し、指定した場合は更新します。

取り込んでもらえると嬉しいです :sushi:
