### PR TITLE
invite user who haven't logged in yet

### DIFF
--- a/app/controllers/room_controller.rb
+++ b/app/controllers/room_controller.rb
@@ -44,7 +44,8 @@ class RoomController < ApplicationController
           @room.members = params[:room][:members].map do |_, user_name|
             user = User.where(:screen_name => user_name).first
             if user.nil? then
-              []
+              User.new(:screen_name => user_name,
+                       :profile_image_url => "data:image/gif;base64,R0lGODlhEAAQAMQfAFWApnCexR4xU1SApaJ3SlB5oSg9ZrOVcy1HcURok/Lo3iM2XO/i1lJ8o2eVu011ncmbdSc8Zc6lg4212DZTgC5Hcmh3f8OUaDhWg7F2RYlhMunXxqrQ8n6s1f///////yH5BAEAAB8ALAAAAAAQABAAAAVz4CeOXumNKOpprHampAZltAt/q0Tvdrpmm+Am01MRGJpgkvBSXRSHYPTSJFkuws0FU8UBOJiLeAtuer6dDmaN6Uw4iNeZk653HIFORD7gFOhpARwGHQJ8foAdgoSGJA1/HJGRC40qHg8JGBQVe10kJiUpIQA7")
             else
               user
             end

--- a/lib/asakusa_satellite/omniauth/adapter.rb
+++ b/lib/asakusa_satellite/omniauth/adapter.rb
@@ -2,9 +2,13 @@ module AsakusaSatellite
   module OmniAuth
     class Adapter
       def self.adapt(omniauth_hash)
-        User.new(:name => omniauth_hash.info.name,
-                 :screen_name => omniauth_hash.info.nickname,
-                 :profile_image_url => omniauth_hash.info.image)
+        info = omniauth_hash.info
+
+        User.find_or_create_by(:screen_name => info.nickname).tap do |user|
+          user.name = info.name if info.name
+          user.profile_image_url = info.image if info.image
+          user.save
+        end
       end
     end
   end


### PR DESCRIPTION
This commit enables user to invite users who haven't logged in AsakusaSatellite yet to private rooms.
When the invited user log in, username and profile image are set correctly.
