### PR TITLE
notify message owner with gcm refs #93

### DIFF
--- a/plugins/as_chrome_notifier/lib/as_chrome_notifier.rb
+++ b/plugins/as_chrome_notifier/lib/as_chrome_notifier.rb
@@ -6,7 +6,7 @@ class ChromeNotifierListener < AsakusaSatellite::Hook::Listener
     message = context[:message]
     room = context[:room]
 
-    (room.owner_and_members - [message.user]).each do |member|
+    room.owner_and_members.each do |member|
       member.devices.each do |device|
         channel_id = device.name
         Chrome.send(channel_id, message.id) unless channel_id.nil?


### PR DESCRIPTION
Message owner should also be notified with gcm.

The client application have to access the server and get the message body for all notifications
because the client application can't keep websocket connection(at least for now).
