### PR TITLE
Added: url to Attachment#to_json refs #108

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -38,7 +38,8 @@ class Attachment
     {
       :disk_filename => File.basename(self.disk_filename || '' ),
       :filename => self.filename,
-      :content_type => self.mimetype
+      :content_type => self.mimetype,
+      :url => self.url
     }
   end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Attachment do
   before do
-    @attachment = Attachment.new(:disk_filename => '/tmp/file.png',
+    @attachment = Attachment.new(:disk_filename => '/public/file.png',
                                  :filename => 'file.png',
                                  :mimetype => 'image/png')
 
@@ -17,6 +17,7 @@ describe Attachment do
     its([:disk_filename]) { should == "file.png"  }
     its([:filename])      { should == "file.png"  }
     its([:content_type])  { should == "image/png" }
+    its([:url])  { should == "/file.png" }
   end
 
   describe "create_and_save_file" do


### PR DESCRIPTION
I added `url` field to attachment json.

If you use `LocalStorePolicy`, you'll get json like below.

```
attachment: [
    {
        disk_filename: "d1b8ed40-ee95-40c2-8598-56f7b5c73e12-test.jpg",
        filename: "test.jpg",
        content_type: "image/jpeg",
        url: "/upload/d1b8ed40-ee95-40c2-8598-56f7b5c73e12-test.jpg"
    }
],
```

If you use `WatagePolicy`, you'll get json like below.

```
attachment: [
    {
        disk_filename: "",
        filename: "test.jpg",
        content_type: "image/jpeg",
        url: "http://dl.dropbox.com/u/xxxxx/5af9ac23-749f-4128-b6bd-69386d4b4670_test.jpg"
    }
],
```

This means AsakusaSatellite newly provides an easy way to get permalink of attachment files.
