### PR TITLE
Added: emoji hosting with gemoji gem refs #76

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -68,6 +68,12 @@ module AsakusaSatellite
     # Enable the asset pipeline
     config.assets.enabled = true
 
+    # gemoji
+    if defined?(Emoji)
+      config.assets.paths << Emoji.images_path
+      config.assets.precompile << "emoji/*.png"
+    end
+
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 

--- a/plugins/as_emoji_filter/README.markdown
+++ b/plugins/as_emoji_filter/README.markdown
@@ -3,21 +3,3 @@ as\_emoji\_filter
 
 This plugin enables you to use emojis in AS.
 
-Setup
-----------------
-
-1. Set `AS_EMOJI_URL_ROOT` env variable.(e.g. `http://www.emoji-cheat-sheet.com/graphics/emojis` )
-
-2. Restart AsakusaSatellite
-
-Hosting on your server(Recommend)
----------------------------------
-
-Download github emoji:
-
-    cd /tmp
-    git clone git://github.com/arvida/emoji-cheat-sheet.com.git
-    mkdir -p /path/to/AsakusaSatellite/public/emoji
-    mv emoji-cheat-sheet/public/graphics/*.png /path/to/AsakusaSatellite/public/emoji/
-
-Set `http://your-domain.example.com/emoji` as `AS_EMOJI_URL_ROOT`.

--- a/plugins/as_emoji_filter/lib/emoji_filter.rb
+++ b/plugins/as_emoji_filter/lib/emoji_filter.rb
@@ -1,12 +1,14 @@
 require 'gemoji'
 
 class EmojiFilter < AsakusaSatellite::Filter::Base
+  include Sprockets::Helpers::RailsHelper
+  include Sprockets::Helpers::IsolatedHelper
+
   def process(text, opts={})
-    root = URI(ENV["AS_EMOJI_URL_ROOT"]+"/")
     text.gsub!(/:([^:\s]+):/) do
       icon = $1
       if Emoji.names.include?(icon)
-        url = root + URI.escape("#{icon}.png",/[^-_.!~*'()a-zA-Z\d;\/?:@&=$,\[\]]/)
+        url = asset_path("emoji/#{icon}.png")
         %(<img src="#{url}" style="width:16px" title="#{icon}" alt="#{icon}"/>)
       else
         ":#{icon}:"

--- a/plugins/as_emoji_filter/spec/lib/emoji_filter_spec.rb
+++ b/plugins/as_emoji_filter/spec/lib/emoji_filter_spec.rb
@@ -4,7 +4,6 @@ require 'emoji_filter'
 describe EmojiFilter do
   before do
     @filter = EmojiFilter.new({})
-    ENV['AS_EMOJI_URL_ROOT'] = 'http://example.com/emoji'
   end
 
   describe "non emoji" do
@@ -28,7 +27,7 @@ describe EmojiFilter do
       @filter.process(":sushi:")
     }
 
-    it { should == %(<img src="http://example.com/emoji/sushi.png" style="width:16px" title="sushi" alt="sushi"/>) }
+    it { should == %(<img src="/assets/emoji/sushi.png" style="width:16px" title="sushi" alt="sushi"/>) }
   end
 
   describe "emoji with tailing-slash" do
@@ -36,7 +35,7 @@ describe EmojiFilter do
       @filter.process(":sushi:")
     }
 
-    it { should == %(<img src="http://example.com/emoji/sushi.png" style="width:16px" title="sushi" alt="sushi"/>) }
+    it { should == %(<img src="/assets/emoji/sushi.png" style="width:16px" title="sushi" alt="sushi"/>) }
   end
 
   describe "non-existent emoji" do


### PR DESCRIPTION
This patch removes `ENV['AS_EMOJI_URL_ROOT']` configuration.
But I'm afraid that precompile may cost longer time. :disappointed_relieved:
