### PR TITLE
Remove: warning: encountered \r in middle of line

### DIFF
--- a/plugins/as_code_highlight_filter/Gemfile
+++ b/plugins/as_code_highlight_filter/Gemfile
@@ -1,1 +1,2 @@
 gem 'coderay'
+

--- a/plugins/as_iphone_notifier/Gemfile
+++ b/plugins/as_iphone_notifier/Gemfile
@@ -1,1 +1,2 @@
-gem 'apns'
+gem 'apns'
+


### PR DESCRIPTION
Ruby 2.1 says

```
(eval):1: warning: encountered \r in middle of line, treated as a mere space
```

refs #163 
