### PR TITLE
Desktop notification window is not closed automatically on Google Chrome 33

### DIFF
--- a/plugins/as_desktopnotification/app/assets/javascripts/desktopnotification_notify.js
+++ b/plugins/as_desktopnotification/app/assets/javascripts/desktopnotification_notify.js
@@ -73,8 +73,12 @@
                 var delay = $.LocalStorage.get('notificationTime', 3);
                 if (delay > 0) {
                     setTimeout(function() {
-                        popup.cancel();
-                    }, delay*1000);
+                        if (popup.cancel) {
+                            popup.cancel();
+                        } else if (popup.close) {
+                            popup.close();
+                        }
+                    }, delay * 1000);
                 }
             }
         }


### PR DESCRIPTION
`Notification#cancel` method changed to `Notification#close`.
