### PR TITLE
api/v1/user.json returns a user without api_key

### DIFF
--- a/app/controllers/api/v1/user_controller.rb
+++ b/app/controllers/api/v1/user_controller.rb
@@ -3,10 +3,13 @@ module Api
   module V1
     class UserController < ApplicationController
       include ApiHelper
+
+      before_filter :check_spell
+
       def show
-        users = User.where(:spell => params[:api_key])
-        if users.first
-          render :json => users.first.to_json
+        user = current_user
+        if user
+          render :json => user.to_json
           return
         end
         render_error 'user not found', 403
@@ -42,7 +45,7 @@ module Api
 
       private
       def manage_device(&proc)
-        user = User.where(:spell => params[:api_key]).first
+        user = current_user
         unless user
           render_error 'user not found', 403
           return

--- a/spec/controllers/api/v1/user_controller_spec.rb
+++ b/spec/controllers/api/v1/user_controller_spec.rb
@@ -9,6 +9,10 @@ describe Api::V1::UserController do
                      :profile_image_url => 'url',
                      :spell => 'spell')
     @user.save!
+    User.new(:name => 'test',
+             :screen_name => 'test-name',
+             :profile_image_url => 'test-url',
+             :spell => nil).save!
   end
 
   describe "show" do
@@ -26,6 +30,16 @@ describe Api::V1::UserController do
     context "api_keyが不一致" do
       before {
         get :show, :api_key => "peropero", :format => 'json'
+      }
+      subject { response }
+      its(:response_code) { should == 403 }
+      its(:body) { should have_json("/status[text() = 'error']") }
+      its(:body) { should have_json("/error[text() = 'user not found']") }
+    end
+
+    context "without api_key" do
+      before {
+        get :show, :api_key => nil, :format => 'json'
       }
       subject { response }
       its(:response_code) { should == 403 }
@@ -58,7 +72,7 @@ describe Api::V1::UserController do
         devices = mock 'devices'
         devices.stub(:where => [mock('device')])
         user.stub(:save => false, :devices => devices, :to_json => '')
-        User.stub(:where => [user])
+        controller.stub(:current_user) { user }
         post :add_device, :api_key => @user.spell, :format => 'json', :device => 'device_id'
       }
       subject { response }


### PR DESCRIPTION
If a user that has no api key exists, api/v1/user.json returns the user.
Created users usually have auto-generated api keys,
but old users do not have api keys.
So this problem may show secret users. 
