### PR TITLE
Searching for regexp meta character failed

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -99,7 +99,8 @@ class Message
     query = params[:text]
     rooms = (params[:rooms] || Room.all_live).select {|room| not room.deleted}
     rooms.map do |room|
-      condition = {:room_id => room._id, "$or" => [{:body => /#{query}/i}, {"attachments.filename" => /#{query}/i}]}
+      regexp = /#{Regexp.escape(query)}/i
+      condition = {:room_id => room._id, "$or" => [{:body => regexp}, {"attachments.filename" => regexp}]}
       condition.merge!({:_id.lt => params[:message_id]}) unless params[:message_id].blank?
       messages = Message.where(condition)
       messages = messages.limit(params[:limit]) if params[:limit]

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -144,6 +144,15 @@ describe Message do
         it_should_behave_like 'メッセージ有'
       end
     end
+
+    context "with Regexp meta characters" do
+      context "for (" do
+        before { @result = Message.find_by_text(:text => "(") }
+        subject { @result }
+        it { should have(2).item }
+        it_should_behave_like 'メッセージ無'
+      end
+    end
   end
 
   describe "メッセージの保存・破棄に失敗する" do


### PR DESCRIPTION
When I search for "(", AsakusaSatellite throws exceptions

```
end pattern with unmatched parenthesis: /(/i
```

It need `Regexp.escape` .
