### PR TITLE
Miss escaping when message body contains ' with as_redmine_ticket_link_filter

### DIFF
--- a/config/initializers/ruby_patch.rb
+++ b/config/initializers/ruby_patch.rb
@@ -6,12 +6,3 @@ class Array
   end
 end
 
-class CGI
-  class << self
-    alias_method :orig_escapeHTML, :escapeHTML
-    def escapeHTML(str)
-      orig_escapeHTML(str).gsub("'", "&#39;")
-    end
-  end
-end if RUBY_VERSION < '2.0.0'
-

--- a/plugins/as_code_highlight_filter/lib/code_highlight_filter.rb
+++ b/plugins/as_code_highlight_filter/lib/code_highlight_filter.rb
@@ -3,7 +3,7 @@ class CodeHighlightFilter < AsakusaSatellite::Filter::Base
 
   def process_all(lines, opts={})
     lang,*body = lines
-    content = CGI.unescapeHTML(body.join("\n"))
+    content = REXML::Text::unnormalize(body.join("\n"))
     case lang
     when "graphviz::","graph::"
       %(<img class="graphviz" src="http://chart.googleapis.com/chart?cht=gv&amp;chl=#{CGI.escape content}" />)

--- a/plugins/as_redmine_ticket_link_filter/lib/redmine_ticket_link_filter.rb
+++ b/plugins/as_redmine_ticket_link_filter/lib/redmine_ticket_link_filter.rb
@@ -7,6 +7,7 @@ class AsakusaSatellite::Filter::RedmineTicketLinkFilter < AsakusaSatellite::Filt
   def process(line, opts={})
     room = opts[:room]
     info = room.yaml[:redmine_ticket]
+    return line if info.blank?
     line.gsub(/#(\d+)/) {|id|
       ticket $1, id, info
     }
@@ -24,7 +25,7 @@ class AsakusaSatellite::Filter::RedmineTicketLinkFilter < AsakusaSatellite::Filt
       begin
         open(api.to_s) do|io|
           hash = JSON.parse(io.read)
-          subject = CGI::escapeHTML hash["issue"]["subject"]
+          subject = REXML::Text::normalize hash["issue"]["subject"]
           if subject.respond_to? :force_encoding
             subject.force_encoding 'utf-8'
           end


### PR DESCRIPTION
1. you post a message that contains ' (for example: &lt;strong&gt;μ's&lt;/strong&gt;)
2. ' is escaped to &amp;# 39;
3. as_redmine_ticket_link_filter processes # to &lt;a /&gt;
4. &&lt;a /&gt; is not well-formed xml, it causes exception
5. rescue catches the exception
6. original message returns from rescue block
7. you will get  &lt;strong&gt;μ's&lt;/strong&gt; as HTML string
