### PR TITLE
AbstractController::DoubleRenderError on search_more

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -44,8 +44,8 @@ class SearchController < ApplicationController
       if @results.size > 0
         @messages = @results.first[:messages].reverse!
       end
+      render :template => 'chat/messages', :layout => false
     end
-    render :template => 'chat/messages', :layout => false
   end
 
   private

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -90,6 +90,12 @@ describe SearchController do
       it { should be_nil }
     end
 
+    context "存在しない部屋" do
+      before { get :search_more, :search_message => 'foo', :room_id => 'not_exisiting_room_id'}
+      subject { response }
+      it { should redirect_to(:controller => 'chat', :action => 'index') }
+    end
+
     context "検索結果がある" do
       before do
         @room = mock


### PR DESCRIPTION
If `RoomHelper#find_room` failed, `SearchController#search_more` fails.
