### PR TITLE
AsakusaSatellite::Application.config.secret_token is insecure

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
       "description": "QuoteIt URL",
       "value": "https://quoteit.herokuapp.com"
     },
-    "SECRET_KEY_BASE": {
+    "SECRET_TOKEN": {
       "description": "A secret key for verifying the integrity of signed cookies",
       "generator": "secret"
     }

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-AsakusaSatellite::Application.config.secret_token = ENV['SECRET_KEY_BASE'] || '757e1ab289018387107b419f801bccc94017432f61542e0a3ef9a29d3a968670fb122e77150ddb079ab159c65d6710a3b54a2392b4f46a2ff9323bd3eb761fa7'
+AsakusaSatellite::Application.config.secret_token = ENV['SECRET_TOKEN'] || '757e1ab289018387107b419f801bccc94017432f61542e0a3ef9a29d3a968670fb122e77150ddb079ab159c65d6710a3b54a2392b4f46a2ff9323bd3eb761fa7'


### PR DESCRIPTION
We should keep `secret_token` value secret in config/initializers/secret_token.rb.
But AsakusaSatellite keeps the value as plain.

refs:
http://daniel.fone.net.nz/blog/2013/05/20/a-better-way-to-manage-the-rails-secret-token/
