### PR TITLE
failure to access to login/failure with ActionController::RedirectBackError: No HTTP_REFERER

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -37,6 +37,10 @@ class LoginController < ApplicationController
   end
 
   def failure
-    redirect_to :back, :alert => params[:message]
+    if request.env["HTTP_REFERER"]
+      redirect_to :back, :alert => params[:message]
+    else
+      redirect_to root_path, :alert => params[:message]
+    end
   end
 end

--- a/spec/controllers/login_controller_spec.rb
+++ b/spec/controllers/login_controller_spec.rb
@@ -42,4 +42,20 @@ describe LoginController do
     its(:screen_name) { should == 'nickname' }
     its(:profile_image_url) { should == 'http://example.com/a.jpg' }
   end
+
+  context "login/failure" do
+    context "access from other page" do
+      before do
+        request.env["HTTP_REFERER"] = "http://example.com"
+        get :failure
+      end
+      it { should redirect_to "http://example.com" }
+    end
+    context "access directly" do
+      before do
+        get :failure
+      end
+      it { should redirect_to root_path }
+    end
+  end
 end


### PR DESCRIPTION
When I accessed login/failure directly, AsakusaSatellite crashed with following error:

```
ActionController::RedirectBackError: No HTTP_REFERER was set in the request to this action, so redirect_to :back could not be called successfully. If this is a test, make sure to specify request.env["HTTP_REFERER"].
```
