### PR TITLE
emoji characters are broken on WebSocket

### DIFF
--- a/config/initializers/active_support_json_encoding_patch.rb
+++ b/config/initializers/active_support_json_encoding_patch.rb
@@ -1,0 +1,14 @@
+# patch to fix ActiveSupport:JSON::Encoding does not support emoji
+module ActiveSupport
+  module JSON
+    module Encoding
+      class << self
+        def escape_with_json_gem(string)
+          ::JSON.generate([string], :ascii_only => true)[1..-2]
+        end
+        alias_method_chain :escape, :json_gem
+      end
+    end
+  end
+end
+

--- a/spec/lib/asakusa_satellite/patch_spec.rb
+++ b/spec/lib/asakusa_satellite/patch_spec.rb
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+require File.dirname(__FILE__) + '/../../spec_helper'
+
+describe 'patch' do
+  describe "active_support_json_encoding" do
+    subject { JSON.parse("[#{'🍣'.to_json}]") }
+    it { should == ["🍣"] }
+  end
+end


### PR DESCRIPTION
```ActiveSupport::JSON::Encoding``` does not support 4-byte characters. :sushi: 