### PR TITLE
add quoted text push

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -33,8 +33,15 @@ class Message
     }
   end
 
-  def html_body(room)
+  def html_body(room = nil)
     AsakusaSatellite::Filter.process self, room || self.room
+  end
+
+  def inner_text
+    doc = REXML::Document.new(html_body || '')
+    doc.delete_element('//style')
+    doc.delete_element('//script')
+    REXML::XPath.match(doc, "//text()").join(" ").strip
   end
 
   def prev(offset)

--- a/plugins/as_iphone_notifier/lib/asakusa_satellite/apn_service/base.rb
+++ b/plugins/as_iphone_notifier/lib/asakusa_satellite/apn_service/base.rb
@@ -25,8 +25,10 @@ module AsakusaSatellite
       def send_message(device_tokens, room, message); end
 
       def alert(message)
-        not_attached = message.attachments.empty?
-        body = not_attached ? message.body : message.attachments[0].filename
+        body = ''
+        body = message.attachments[0].filename unless message.attachments.empty?
+        body = message.inner_text if body.blank?
+        body = message.body if body.blank?
         strip("#{message.user.name} / #{body}", PAYLOAD_SIZE_LIMIT)
       end
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -190,6 +190,33 @@ describe Message do
     end
   end
 
+  describe "inner_text" do
+    context 'simple' do
+      before {
+        @message = Message.new
+        allow(@message).to receive(:html_body).and_return('<div class="body">text</div>')
+      }
+      subject { @message }
+      its(:inner_text) { should == "text" }
+    end
+    context 'not html' do
+      before {
+        @message = Message.new
+        allow(@message).to receive(:html_body).and_return('text')
+      }
+      subject { @message }
+      its(:inner_text) { should == "text" }
+    end
+    context 'html with style' do
+      before {
+        @message = Message.new
+        allow(@message).to receive(:html_body).and_return('<div><style>html{color:red;}</style> <div>text</div></div>')
+      }
+      subject { @message }
+      its(:inner_text) { should == "text" }
+    end
+  end
+
   describe "添付ファイル" do
     before {
       expect(Setting).to receive(:[]).with(:attachment_max_size).and_return("1")


### PR DESCRIPTION
Apple Push Notification for quoted message contains only URL.
We need quoted inner texts.