### PR TITLE
Fixed: broken emoji suggestions

### DIFF
--- a/plugins/as_emoji_filter/app/assets/javascripts/emoji_completer.js.erb
+++ b/plugins/as_emoji_filter/app/assets/javascripts/emoji_completer.js.erb
@@ -13,7 +13,7 @@ $(function(){
         return ":" + value + ":";
       },
       template: function(value){
-        return "<img src='<%= ActionController::Base.helpers.asset_path('emoji') %>/" + value + ".png'>" + value + "</img>";
+        return "<img src='<%= Rails.application.config.relative_url_root %><%= ActionController::Base.helpers.asset_path('emoji') %>/" + value + ".png'>" + value + "</img>";
       },
       maxCount: 5,
     }


### PR DESCRIPTION
Images of Emoji completion were broken in sub directory URL.

```AssetHelper.asset_path('emoji')``` does not add a relative_url_root outside view.
