### PR TITLE
Mongolab用のオプションを追加

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -16,3 +16,5 @@ production:
   clients:
     default:
       uri: <%= ENV['MONGODB_URI'] || ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI'] %>
+      options:
+        retry_writes: false


### PR DESCRIPTION
> Mongo::Error::OperationFailure: Transaction numbers are only allowed on storage engines that support document-level locking (20) (on ds039737-a.mlab.com:39737, attempt 1) This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string or use the retry_writes: false Ruby client option

を回避するためにオプションを追加