### PR TITLE
プラグインフックが動いてなかったので修正

### DIFF
--- a/lib/asakusa_satellite/hook.rb
+++ b/lib/asakusa_satellite/hook.rb
@@ -22,7 +22,7 @@ module AsakusaSatellite::Hook
         else
           begin
             elem = listener.send(hook, context)
-            html + ((elem.class == String and not elem.nil?) ? elem : '')
+            html + ((elem.is_a?(String) and not elem.nil?) ? elem : '')
           rescue => e
             Rails.logger.error e
             html


### PR DESCRIPTION
## サマリ
プラグインフックが動いてなかったので修正。 (i.e. `AsakusaSatellite::Hook.call_hook` が常に空文字列を返す)

## 原因
Rails 4から`render_to_string`の返り値としてRails::SafeBufferが使われるようになったため、 `elem.clas == String` が常に不成立になっていた。
