### PR TITLE
Compassを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'socky-client', '>= 0.5.0.beta1'
 # html
 gem 'haml-rails'
 gem 'sass-rails', '5.0.8'
-gem 'compass-rails', '3.1.0'
 gem "execjs"
 gem 'therubyracer', :platform => :ruby
 gem 'uglifier', '~> 2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,23 +68,6 @@ GEM
     c2dm (0.2.2)
       httparty
       json
-    chunky_png (1.3.11)
-    compass (1.0.3)
-      chunky_png (~> 1.2)
-      compass-core (~> 1.0.2)
-      compass-import-once (~> 1.0.5)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-      sass (>= 3.3.13, < 3.5)
-    compass-core (1.0.3)
-      multi_json (~> 1.0)
-      sass (>= 3.3.0, < 3.5)
-    compass-import-once (1.0.5)
-      sass (>= 3.2, < 3.5)
-    compass-rails (3.1.0)
-      compass (~> 1.0.0)
-      sass-rails (< 5.1)
-      sprockets (< 4.0)
     concurrent-ruby (1.1.5)
     crack (0.1.8)
     crass (1.0.4)
@@ -347,7 +330,6 @@ PLATFORMS
 DEPENDENCIES
   apns
   c2dm
-  compass-rails (= 3.1.0)
   eventmachine
   execjs
   faraday

--- a/app/assets/stylesheets/main.css.sass.erb
+++ b/app/assets/stylesheets/main.css.sass.erb
@@ -1,5 +1,3 @@
-@import "compass"
-
 // variable
 $link-color: #e2041b
 $link-visited-color: #e597b2
@@ -22,7 +20,7 @@ body
   margin: auto
   border: 1px solid #ccc
   background-color: #fff
-  @include box-shadow(1px 1px 2px #999)
+  box-shadow: 1px 1px 2px #999
 
 #audio
   display: none
@@ -46,7 +44,7 @@ body
   display: none
   opacity: 0
   box-shadow: 0px 0px 10px 5px #e2949b inset
-  @include single-transition(opacity, 0.2s, linear)
+  transition: opacity 0.2s linear
 
 .yield
   width: 660px
@@ -65,8 +63,8 @@ body
       padding-right: 50px
 
 .room-info
-  @include background(linear-gradient(top, #fbfbfb 41%, #ededed 100%), #f9f9f9)
-  @include border-radius(5px)
+  background: linear-gradient(top, #fbfbfb 41%, #ededed 100%), #f9f9f9
+  border-radius: 5px
   border: 1px solid #ccc
   font-size: 100%
   padding: 5px
@@ -150,9 +148,9 @@ a img
   padding-left: 10px
   padding-right: 10px
   margin-bottom: 3px
-  @include border-radius(3px)
-  @include background(linear-gradient(top, #fcfcfc 40%, #efefef 100%), #fcfcfc)
-  @include box-shadow(0 1px 1px #ccc)
+  border-radius: 3px
+  background: linear-gradient(top, #fcfcfc 40%, #efefef 100%), #fcfcfc
+  box-shadow: 0 1px 1px #ccc
   font-size: 90%
   div
     padding: 0
@@ -202,12 +200,12 @@ a img
     img
       max-width: 500px
       max-height: 500px
-      @include border-radius(5px)
-      @include box-shadow(1px 1px 2px #999)
+      border-radius: 5px
+      box-shadow: 1px 1px 2px #999
     video
       max-width: 500px
       max-height: 500px
-      @include box-shadow(1px 1px 2px #999)
+      box-shadow: 1px 1px 2px #999
 
 .message.target
   border: 3px solid #ccc
@@ -220,7 +218,7 @@ a img
   cursor: pointer
   margin-bottom: 5px
   padding: 3px
-  @include border-radius(4px)
+  border-radius: 4px
   text-decoration: underline
   img
     width: 16px
@@ -275,7 +273,7 @@ img.profile
         max-height: 20px
         padding-right: 5px
       border: 1px solid #DDD
-      @include border-radius(3px)
+      border-radius: 3px
       list-style:-type none
       padding: 5px
       position: relative
@@ -364,8 +362,8 @@ form.inputarea
   padding: 5px 10px 6px
   color: #fff
   text-decoration: none
-  @include border-radius(6px)
-  @include box-shadow(0 1px 3px rgba(0,0,0,0.6))
+  border-radius: 6px
+  box-shadow: 0 1px 3px rgba(0,0,0,0.6)
   text-shadow: 0 -1px 1px rgba(0,0,0,0.25)
   border-bottom: 1px solid rgba(0,0,0,0.25)
   position: relative
@@ -435,7 +433,7 @@ form.inputarea
   .main
     width: $width
     margin: 0
-    @include box-shadow(0 0 0 #fff)
+    box-shadow: 0 0 0 #fff
   .header
     margin: 0
     img
@@ -455,12 +453,12 @@ form.inputarea
       img
         max-width: $width - 30px
         max-height: $width - 30px
-        @include border-radius(5px)
-        @include box-shadow(1px 1px 2px #999)
+        border-radius: 5px
+        box-shadow: 1px 1px 2px #999
       video
         max-width: $width - 30px
         max-height: $width - 30px
-        @include box-shadow(1px 1px 2px #999)
+        box-shadow: 1px 1px 2px #999
 
   .text
     font-size: 18px

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,12 +3,9 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
-# Add additional assets to the asset load path.
+# Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path
-# Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 # Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in the app/assets
-# folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+Rails.application.config.assets.precompile += %w( jquery-pagination.js jquery-watch.js room.js)


### PR DESCRIPTION
compass-railsはメンテナンスが停止しているし、現代のCSSは十分な表現能力を持つので、compassへの依存を削除する。