### PR TITLE
Enable Heroku App Reviews

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,10 @@
       "description": "Filter file name",
       "value": "filter"
     },
+    "SETTINGS": {
+      "description": "Settings file name",
+      "value": "settings"
+    },
     "MESSAGE_PUSHER_ENGINE": {
       "description": "Message pusher type",
       "value": "pusher"

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,5 +1,13 @@
 class Setting
-  @@available_settings = YAML::load(ERB.new(File.read("#{Rails.root}/config/settings.yml")).result)
+  class << self
+    def settings_path
+      name = "#{ENV['SETTINGS'] || 'settings'}.yml"
+      Rails.root.join('config', name)
+    end
+  end
+
+  @@available_settings = YAML::load(ERB.new(File.read(settings_path)).result)
+
   def self.[](key)
     @@available_settings[key.to_s]
   end

--- a/config/filter_local.yml
+++ b/config/filter_local.yml
@@ -1,0 +1,27 @@
+#
+# Filter setting for internet environment.
+# To use this setting, set FILTER_NAME variable to 'filter.yml'.
+# For details, check http://docs.asakusa-satellite.org/
+#
+
+info:
+ version: 2
+
+filters:
+ - name: code_highlight_filter
+ - name: quote_it
+ - name: revision_it_filter
+ - name: redmine_ticket_link_filter
+ - name: twitter_link
+ - name: emoji_filter
+
+plugins:
+ - dir: as_desktopnotification
+ - dir: as_android_notifier
+ - dir: as_iphone_notifier
+ - dir: as_chrome_notifier
+ - dir: as_profile_setting
+ - dir: as_device_setting
+ - dir: as_global_js_css
+ - dir: as_watage_plugin
+ - dir: as_localauth_plugin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
 
   get 'message', '/chat/show/:id', :controller => "chat", :action=> "show"
 
-  get '/auth/:provider/callback', :to => 'login#omniauth_callback'
+  match '/auth/:provider/callback', :to => 'login#omniauth_callback', :via => [:get, :post]
   get '/auth/failure', :to => 'login#failure'
   get '/login/index', :controller => 'login', :action => 'index'
   post '/login/logout', :controller => 'login', :action => 'logout'

--- a/config/settings_local.yml
+++ b/config/settings_local.yml
@@ -1,0 +1,9 @@
+omniauth:
+  provider: "local"
+
+# file attachment
+attachment_policy: <%= ENV['SETTINGS_ATTACHMENT_POLICY'] || "local" %>
+attachment_path: <%= ENV['SETTINGS_ATTACHMENT_PATH'] || "public/upload" %>
+attachment_max_size: <%= ENV['SETTINGS_ATTACHMENT_MAX_SIZE'] %>
+watage_token: <%= ENV['SETTINGS_WATAGE_ACCESS_TOKEN'] || "00000000-0000-0000-0000-000000000000" %>
+watage_token_secret: <%= ENV['SETTINGS_WATAGE_ACCESS_TOKEN_SECRET'] || "00000000-0000-0000-0000-000000000000" %>

--- a/lib/asakusa_satellite/message_pusher.rb
+++ b/lib/asakusa_satellite/message_pusher.rb
@@ -54,7 +54,7 @@ module AsakusaSatellite
 
       def jsClass
         key = @opt['key'] || URI.parse(ENV['PUSHER_URL']).user
-        "new Pusher('#{key}')"
+        "new Pusher('#{key}')".html_safe
       end
     end
 


### PR DESCRIPTION
## Summary
Heroku app reviews を有効にする。

## やったこと
別ドメインではTwitter認証が使えないなどの制限があるので、その対応をした。

 - 環境変数だけでlocal認証に切り替えれるようにする
 - メッセージ通知にPusherを使えるようにする。(Rails4にあげたときに壊れてた)
