### PR TITLE
Safariを再起動してもNotificationが通知されるようにする

### DIFF
--- a/plugins/as_desktopnotification/app/assets/javascripts/desktopnotification_notify.js
+++ b/plugins/as_desktopnotification/app/assets/javascripts/desktopnotification_notify.js
@@ -62,7 +62,7 @@
 
         var setting = $.extend(defaults, options);
         if ($.DesktopNotification.isAvailable()) {
-            if (!$.DesktopNotification.checkPermission()) {
+            if ($.DesktopNotification.checkPermission() != 2) {
                 var popup = $.DesktopNotification.createNotification(
                     setting.picture,
                     setting.title,


### PR DESCRIPTION
Safari 13.0.4 (15608.4.9.1.3)では通知を許可しても、再起動後はpermissionがdefaultになる。

なので、deniedでない限りは通知を出すようにする。