### PR TITLE
Install bundler manually for Docker environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 ruby ENV['CUSTOM_RUBY_VERSION'] || '2.6.5'
 
 gem 'rails', '6.0.0'
+gem 'bundler'
 
 # mongoid
 gem 'mongoid', '7.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,8 +131,6 @@ GEM
     httpclient (2.8.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    jruby-jars (9.2.8.0)
-    jruby-rack (1.1.21)
     json (2.2.0)
     json (2.2.0-java)
     json_pure (2.2.0)
@@ -273,7 +271,6 @@ GEM
     ruby-hmac (0.4.0)
     ruby_parser (3.14.0)
       sexp_processor (~> 4.9)
-    rubyzip (1.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
@@ -332,11 +329,6 @@ GEM
     unf (0.1.4-java)
     unf_ext (0.0.7.6)
     uuidtools (2.1.5)
-    warbler (2.0.5)
-      jruby-jars (>= 9.0.0.0)
-      jruby-rack (>= 1.1.1, < 1.3)
-      rake (>= 10.1.0)
-      rubyzip (~> 1.0, < 1.4)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.1-java)
@@ -358,6 +350,7 @@ PLATFORMS
 
 DEPENDENCIES
   apns
+  bundler
   c2dm
   eventmachine
   execjs
@@ -388,7 +381,6 @@ DEPENDENCIES
   thin
   uglifier
   uuidtools
-  warbler
   zero_push
 
 RUBY VERSION

--- a/script/dockerfiles/Dockerfile.app
+++ b/script/dockerfiles/Dockerfile.app
@@ -2,6 +2,8 @@ FROM ruby:2.6.5
 
 WORKDIR /tmp
 
+RUN gem install bundler -v 2.0.2
+
 RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.6-linux-x86_64.tar.bz2 &&  \
     bzip2 -dc phantomjs-1.9.6-linux-x86_64.tar.bz2 | tar xvf - && \
     mv phantomjs-1.9.6-linux-x86_64/bin/phantomjs /usr/local/bin && \


### PR DESCRIPTION
Docker の ruby:2.5.6 だと bundler のバージョンが古いので bundle install に失敗する。
Dockerfile.app のイメージ作成時に新しい bundler をインストールするようにした。