### PR TITLE
add_device/delete_device 実行前にパラメータチェックを追加

### DIFF
--- a/app/controllers/api/v1/user_controller.rb
+++ b/app/controllers/api/v1/user_controller.rb
@@ -28,6 +28,11 @@ module Api
       end
 
       def add_device
+        unless params[:device] && params[:name]
+          render_error 'device id and name cannot be empty'
+          return
+        end
+
         manage_device do |user|
           if user.devices.where(:name => params[:device]).empty?
             user.devices << Device.new(:name => params[:device],
@@ -45,6 +50,11 @@ module Api
       end
 
       def delete_device
+        unless params[:device]
+          render_error 'device id cannot be empty'
+          return
+        end
+
         manage_device do |user|
           unless user.devices.where(:name => params[:device]).empty?
             device = user.devices.where(:name => params[:device])

--- a/spec/controllers/api/v1/user_controller_spec.rb
+++ b/spec/controllers/api/v1/user_controller_spec.rb
@@ -4,9 +4,16 @@ require File.dirname(__FILE__) + '/../../../spec_helper'
 describe Api::V1::UserController do
   before do
     User.all.each{|u| u.delete }
+
+    device = Device.new(:name => 'hogehoge_id',
+      :device_name => 'hogehoge_phone',
+      :device_type => 'iphone')
+    devices = [device]
+
     @user = User.new(:name => 'name',
                      :screen_name => 'screen-name',
                      :profile_image_url => 'url',
+                     :devices => devices,
                      :spell => 'spell')
     @user.save!
     User.new(:name => 'test',
@@ -100,7 +107,7 @@ describe Api::V1::UserController do
         post :add_device, :params => { :api_key => @user.spell, :format => 'json', :device => 'device_id', :name => 'device_name' }
         @user = @user.reload
       }
-      subject { @user.devices[0].name }
+      subject { @user.devices[1].name }
       it { should == 'device_id' }
     end
     context "api_keyが不一致" do
@@ -125,6 +132,35 @@ describe Api::V1::UserController do
       its(:response_code) { should == 500 }
       its(:body) { should have_json("/status[text() = 'error']") }
       its(:body) { should have_json("/error[text() = 'cannot save device data']") }
+    end
+  end
+
+  describe "delete_device" do
+    context "デバイスIDがない" do
+      before {
+        post :delete_device, :params => { :api_key => @user.spell, :format => 'json' }
+        @user = @user.reload
+      }
+      subject { response }
+      its(:response_code) { should == 500 }
+      its(:body) { should have_json("/status[text() = 'error']") }
+      its(:body) { should have_json("/error[text() = 'device id cannot be empty']") }
+    end
+    context "api_keyが一致" do
+      before {
+        post :delete_device, :params => { :api_key => @user.spell, :format => 'json', :device => 'hogehoge_id' }
+        @user = @user.reload
+      }
+      subject { @user.devices.where(:name => 'hogehoge_id').first }
+      it { should be_nil }
+    end
+    context "api_keyが不一致" do
+      before {
+        post :delete_device, :params => { :api_key => "peropero", :format => 'json', :device => 'hogehoge_id' }
+        @user = @user.reload
+      }
+      subject { @user.devices.where(:name => 'hogehoge_id').first }
+      it { should_not be_nil }
     end
   end
 

--- a/spec/controllers/api/v1/user_controller_spec.rb
+++ b/spec/controllers/api/v1/user_controller_spec.rb
@@ -75,9 +75,29 @@ describe Api::V1::UserController do
   end
 
   describe "add_device" do
-    context "api_keyが一致" do
+    context "デバイスIDがない" do
+      before {
+        post :add_device, :params => { :api_key => @user.spell, :format => 'json', :name => 'device_name' }
+        @user = @user.reload
+      }
+      subject { response }
+      its(:response_code) { should == 500 }
+      its(:body) { should have_json("/status[text() = 'error']") }
+      its(:body) { should have_json("/error[text() = 'device id and name cannot be empty']") }
+    end
+    context "デバイス名がない" do
       before {
         post :add_device, :params => { :api_key => @user.spell, :format => 'json', :device => 'device_id' }
+        @user = @user.reload
+      }
+      subject { response }
+      its(:response_code) { should == 500 }
+      its(:body) { should have_json("/status[text() = 'error']") }
+      its(:body) { should have_json("/error[text() = 'device id and name cannot be empty']") }
+    end
+    context "api_keyが一致" do
+      before {
+        post :add_device, :params => { :api_key => @user.spell, :format => 'json', :device => 'device_id', :name => 'device_name' }
         @user = @user.reload
       }
       subject { @user.devices[0].name }
@@ -85,7 +105,7 @@ describe Api::V1::UserController do
     end
     context "api_keyが不一致" do
       before {
-        post :add_device, :params => { :api_key => "peropero", :format => 'json', :device => 'device_id' }
+        post :add_device, :params => { :api_key => "peropero", :format => 'json', :device => 'device_id', :name => 'device_name' }
       }
       subject { response }
       its(:response_code) { should == 403 }
@@ -99,7 +119,7 @@ describe Api::V1::UserController do
         allow(devices).to receive_messages(:where => [double('device')])
         allow(user).to receive_messages(:save => false, :devices => devices, :to_json => '')
         allow(controller).to receive(:current_user).and_return(user)
-        post :add_device, :params => { :api_key => @user.spell, :format => 'json', :device => 'device_id' }
+        post :add_device, :params => { :api_key => @user.spell, :format => 'json', :device => 'device_id', :name => 'device_name' }
       }
       subject { response }
       its(:response_code) { should == 500 }


### PR DESCRIPTION
現状だとデバイスIDの重複チェックのみ行っており、API の使い方が間違っていると不正なデバイス情報が追加されてしまう。