### PR TITLE
デバイス API の更新

### DIFF
--- a/app/controllers/api/v1/user_controller.rb
+++ b/app/controllers/api/v1/user_controller.rb
@@ -34,10 +34,15 @@ module Api
         end
 
         manage_device do |user|
-          if user.devices.where(:name => params[:device]).empty?
+          devices = user.devices.where(:name => params[:device])
+          if devices.empty?
             user.devices << Device.new(:name => params[:device],
                                        :device_name => params[:name],
                                        :device_type => params[:type] || 'iphone')
+          else
+            device = devices.first
+            device.update_attributes({:device_name => params[:name],
+                                      :device_type => params[:type] || 'iphone'})
           end
 
           unless user.save

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -10,6 +10,15 @@ class Device
     device_type.nil? or device_type == "iphone"
   end
 
+  def to_json
+    {
+      :id => self.id.to_s,
+      :device_name => self.device_name,
+      :device_type => self.device_type,
+      :name => self.name
+      }
+  end
+
   def self.register_callback(event)
     class_eval <<-EOS
       @@_#{event.to_s}_procs = []

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,8 @@ class User
       :name => self.name,
       :screen_name => self.screen_name,
       :profile_image_url => self.profile_image_url,
-      :user_profiles => self.user_profiles.map {|profile| profile.to_json}
+      :user_profiles => self.user_profiles.map {|profile| profile.to_json},
+      :devices => self.devices.map {|device| device.to_json}
     }
   end
 

--- a/spec/controllers/api/v1/user_controller_spec.rb
+++ b/spec/controllers/api/v1/user_controller_spec.rb
@@ -123,7 +123,7 @@ describe Api::V1::UserController do
       before {
         user = double 'user'
         devices = double 'devices'
-        allow(devices).to receive_messages(:where => [double('device')])
+        allow(devices).to receive_messages(:where => [], :<< => devices)
         allow(user).to receive_messages(:save => false, :devices => devices, :to_json => '')
         allow(controller).to receive(:current_user).and_return(user)
         post :add_device, :params => { :api_key => @user.spell, :format => 'json', :device => 'device_id', :name => 'device_name' }
@@ -132,6 +132,15 @@ describe Api::V1::UserController do
       its(:response_code) { should == 500 }
       its(:body) { should have_json("/status[text() = 'error']") }
       its(:body) { should have_json("/error[text() = 'cannot save device data']") }
+    end
+    context "デバイス情報を更新" do
+      before {
+        post :add_device, :params => { :api_key => @user.spell, :format => 'json', :device => 'hogehoge_id', :name => 'new_name', :type => 'chrome' }
+        @user = @user.reload
+      }
+      subject { @user.devices.first }
+      its(:device_name) { should == 'new_name' }
+      its(:device_type) { should == 'chrome' }
     end
   end
 

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -15,6 +15,13 @@ describe Device do
   it { should be_respond_to :device_name }
   it { should be_respond_to :device_type }
 
+  describe "to_json" do
+    subject { @device.to_json }
+    its([:name]) { should == "test-device-token-name" }
+    its([:device_name]) { should == "iphone10" }
+    its([:device_type]) { should == "android" }
+  end
+
   context "Callbacks" do
     context "save" do
       before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,9 @@ describe User do
                          :user_profiles => [UserProfile.new(:room_id => @room1._id,
                                                             :name => "name for room1",
                                                             :profile_image_url => "http://example.com/pic.jpg")],
+                         :devices => [Device.new(:name => "deadbeaf",
+                                                 :device_name => "iPhoneX",
+                                                 :device_type => "iphone")],
                          :spell => 'spell')
   end
 
@@ -30,6 +33,8 @@ describe User do
     its([:name]) { should == "test user" }
     its([:screen_name]) { should == "test" }
     its([:profile_image_url]) { should == "http://example.com/profile.png" }
+    it { should have_key(:user_profiles) }
+    it { should have_key(:devices) }
     it { should_not have_key(:spell) }
     it { should_not have_key(:email) }
   end


### PR DESCRIPTION
/api/v1/user.json のレスポンスに、ユーザのデバイスリストも含めるようにした
/api/v1/user/add_device で、既に登録済みの id で再度登録すると、データを更新するようにした